### PR TITLE
Update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A nodejs binding for [open-korean-text](https://github.com/open-korean-text/open
 
 ## Dependency
 
-Currently wraps [open-korean-text 2.0.4](https://github.com/open-korean-text/open-korean-text/releases/tag/open-korean-text-2.0.4)
+Currently wraps [open-korean-text 2.2.0](https://github.com/open-korean-text/open-korean-text/releases/tag/open-korean-text-2.2.0)
 
-현재 이 프로젝트는 [open-korean-text 2.0.4](https://github.com/open-korean-text/open-korean-text/releases/tag/open-korean-text-2.0.4)을 사용중입니다.
+현재 이 프로젝트는 [open-korean-text 2.2.0](https://github.com/open-korean-text/open-korean-text/releases/tag/open-korean-text-2.2.0)을 사용중입니다.
 
 
 ## Requirement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-korean-text-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Nodejs binding for open-korean-text via java interface.",
   "main": "index.js",
   "types": "lib/index.d.ts",
@@ -25,19 +25,19 @@
   "license": "Apache License 2.0",
   "devDependencies": {
     "@types/java": "^0.7.32",
-    "@types/node": "^8.0.7",
-    "mocha": "^3.4.2",
-    "chai": "^4.0.2",
-    "typescript": "^2.4.1"
+    "@types/node": "^9.4.7",
+    "mocha": "^5.0.4",
+    "chai": "^4.1.2",
+    "typescript": "^2.7.2"
   },
   "dependencies": {
     "es6-promisify": "^5.0.0",
-    "java": "^0.8.0",
+    "java": "^0.9.0",
     "node-wget": "^0.4.2"
   },
   "mavenDependencies": {
-    "scala-library": "http://central.maven.org/maven2/org/scala-lang/scala-library/2.12.0/scala-library-2.12.0.jar",
-    "twitter-text": "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.14.3/twitter-text-1.14.3.jar",
-    "open-korean-text": "http://central.maven.org/maven2/org/openkoreantext/open-korean-text/2.0.4/open-korean-text-2.0.4.jar"
+    "scala-library": "http://central.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar",
+    "twitter-text": "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.14.7/twitter-text-1.14.7.jar",
+    "open-korean-text": "http://central.maven.org/maven2/org/openkoreantext/open-korean-text/2.2.0/open-korean-text-2.2.0.jar"
   }
 }


### PR DESCRIPTION
I update maven and node packages except `es6-promisify`.
(`es6-promisify v6.0.0` is not compatible with this codes)

Now this library supports `open-korean-text v2.2.0`!